### PR TITLE
Create tags decorator to tests

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,3 @@
 [run]
 source = .
-omit = *tests*,.tox/*
+omit = .eggs/*,.tox/*,*tests*,setup.py

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -21,6 +21,7 @@ py==1.6.0                 # via tox
 pycodestyle==2.4.0        # via yala
 pydocstyle==2.1.1         # via yala
 pylint==2.1.1             # via yala
+pytest==5.4.1             # via pytest
 six==1.11.0               # via astroid, pip-tools, pydocstyle, tox
 snowballstemmer==1.2.1    # via pydocstyle
 tox==3.2.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,3 +15,9 @@ known_first_party = kytos.napps,tests
 known_third_party = pyof,kytos
 # Ignoring tests because is adding napps path
 skip=tests
+
+[tool:pytest]
+markers =
+    small: marks tests as small
+    medium: marks tests as medium
+    large: marks tests as large

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ import shutil
 import sys
 from abc import abstractmethod
 from pathlib import Path
-from subprocess import call, check_call
+from subprocess import CalledProcessError, call, check_call
 
 from setuptools import Command, setup
 from setuptools.command.develop import develop
@@ -19,10 +19,7 @@ if 'bdist_wheel' in sys.argv:
     raise RuntimeError("This setup.py does not support wheels")
 
 # Paths setup with virtualenv detection
-if 'VIRTUAL_ENV' in os.environ:
-    BASE_ENV = Path(os.environ['VIRTUAL_ENV'])
-else:
-    BASE_ENV = Path('/')
+BASE_ENV = Path(os.environ.get('VIRTUAL_ENV', '/'))
 
 NAPP_NAME = 'status'
 NAPP_VERSION = '1.1.1'
@@ -58,6 +55,39 @@ class SimpleCommand(Command):
         """Post-process options."""
 
 
+# pylint: disable=attribute-defined-outside-init, abstract-method
+class TestCommand(Command):
+    """Test tags decorators."""
+
+    user_options = [
+        ('size=', None, 'Specify the size of tests to be executed.'),
+        ('type=', None, 'Specify the type of tests to be executed.'),
+    ]
+
+    sizes = ('small', 'medium', 'large', 'all')
+    types = ('unit', 'integration', 'e2e')
+
+    def get_args(self):
+        """Return args to be used in test command."""
+        return '--size %s --type %s' % (self.size, self.type)
+
+    def initialize_options(self):
+        """Set default size and type args."""
+        self.size = 'all'
+        self.type = 'unit'
+
+    def finalize_options(self):
+        """Post-process."""
+        try:
+            assert self.size in self.sizes, ('ERROR: Invalid size:'
+                                             f':{self.size}')
+            assert self.type in self.types, ('ERROR: Invalid type:'
+                                             f':{self.type}')
+        except AssertionError as exc:
+            print(exc)
+            sys.exit(-1)
+
+
 class Cleaner(SimpleCommand):
     """Custom clean command to tidy up the project root."""
 
@@ -70,15 +100,41 @@ class Cleaner(SimpleCommand):
         call('make -C docs/ clean', shell=True)
 
 
-class TestCoverage(SimpleCommand):
-    """Display test coverage."""
+class Test(TestCommand):
+    """Run all tests."""
 
-    description = 'run unit tests and display code coverage'
+    description = 'run tests and display results'
+
+    def get_args(self):
+        """Return args to be used in test command."""
+        markers = self.size
+        if markers == "small":
+            markers = 'not medium and not large'
+        size_args = "" if self.size == "all" else "-m '%s'" % markers
+        return '--addopts="tests/%s %s"' % (self.type, size_args)
 
     def run(self):
-        """Run unittest quietly and display coverage report."""
-        cmd = 'coverage3 run -m unittest && coverage3 report'
-        call(cmd, shell=True)
+        """Run tests."""
+        cmd = 'python setup.py pytest %s' % self.get_args()
+        try:
+            check_call(cmd, shell=True)
+        except CalledProcessError as exc:
+            print(exc)
+
+
+class TestCoverage(Test):
+    """Display test coverage."""
+
+    description = 'run tests and display code coverage'
+
+    def run(self):
+        """Run tests quietly and display coverage report."""
+        cmd = 'coverage3 run setup.py pytest %s' % self.get_args()
+        cmd += '&& coverage3 report'
+        try:
+            check_call(cmd, shell=True)
+        except CalledProcessError as exc:
+            print(exc)
 
 
 class Linter(SimpleCommand):
@@ -92,16 +148,16 @@ class Linter(SimpleCommand):
         check_call('yala *.py tests/test_*.py', shell=True)
 
 
-class CITest(SimpleCommand):
+class CITest(TestCommand):
     """Run all CI tests."""
 
     description = 'run all CI tests: unit and doc tests, linter'
 
     def run(self):
         """Run unit tests with coverage, doc tests and linter."""
-        cmds = ['python3.6 setup.py ' + cmd
-                for cmd in ('coverage', 'lint')]
-        cmd = ' && '.join(cmds)
+        coverage_cmd = 'python3.6 setup.py coverage %s' % self.get_args()
+        lint_cmd = 'python3.6 setup.py lint'
+        cmd = '%s && %s' % (coverage_cmd, lint_cmd)
         check_call(cmd, shell=True)
 
 
@@ -209,6 +265,8 @@ setup(name=f'kytos_{NAPP_NAME}',
       author_email='of-ng-dev@ncc.unesp.br',
       license='MIT',
       install_requires=['setuptools >= 36.0.1'],
+      setup_requires=['pytest-runner'],
+      tests_require=['pytest'],
       extras_require={
           'dev': [
               'coverage',
@@ -225,6 +283,7 @@ setup(name=f'kytos_{NAPP_NAME}',
           'install': InstallMode,
           'lint': Linter,
           'egg_info': EggInfo,
+          'test': Test,
       },
       zip_safe=False,
       classifiers=[

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -1,0 +1,1 @@
+"""kytos/status unit tests."""


### PR DESCRIPTION
Today, all the tests are executed without distinction. This commit creates a tag to divide tests in type (unit, integration, e2e) and in size (small, medium, large, all). "Unit" and "all" are the standard parameters.

To set tags to a test function:

```python
import pytest

@pytest.mark.medium
def test_function():
...
```
To run the tests:

```shell
 python setup.py ci --size=all --type=unit
```

The _'test'_ parameter uses the standard arguments and each function starts with small size argument by default.

By default, Pytest only runs tests inside folder defined in type argument (It isn't necessary to use the type argument in the tag decorator).

Directory hierarchy:

```
/tests/
... e2e/
... integration/
... unit/
```

Related 
https://github.com/kytos/kytos/issues/1041