### PR TITLE
update requirements to solve conflicts: six, click and pluggy

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -8,7 +8,7 @@
 -e .
 -e git+https://github.com/kytos/python-openflow.git#egg=python-openflow
 astroid==2.0.4            # via pylint
-click==6.7                # via pip-tools
+click==7.1.1              # via pip-tools
 coverage==5.0.3
 docopt==0.6.2             # via yala
 first==2.0.1              # via pip-tools
@@ -16,13 +16,13 @@ isort==4.3.4              # via pylint, yala
 lazy-object-proxy==1.3.1  # via astroid
 mccabe==0.6.1             # via pylint
 pip-tools==2.0.2
-pluggy==0.7.1             # via tox
+pluggy                    # via tox
 py==1.6.0                 # via tox
 pycodestyle==2.4.0        # via yala
 pydocstyle==2.1.1         # via yala
 pylint==2.1.1             # via yala
 pytest==5.4.1             # via pytest
-six==1.11.0               # via astroid, pip-tools, pydocstyle, tox
+six==1.15.0               # via astroid, pip-tools, pydocstyle, tox
 snowballstemmer==1.2.1    # via pydocstyle
 tox==3.2.1
 typed-ast==1.1.0          # via astroid


### PR DESCRIPTION
Fix #24 

### :bookmark_tabs: Description of the Change

This PR updates the version of some dev requirements due to conflicts (especially with Kytos 2020.2):
- six==1.11.0 => six==1.15.0
- click==6.7 => click==7.1.1
- pluggy==0.9.0 => pluggy

### :computer: Verification Process

To test this fix, I've run the unit tests using tox:

- created a docker container based on the image python:3.6
- install tox with pip install tox
- clone and run the unit tests for kytos/status:
```
============================================================ test session starts =============================================================
platform linux -- Python 3.6.13, pytest-5.4.1, py-1.6.0, pluggy-0.13.1
cachedir: .tox/py36/.pytest_cache
rootdir: /status, inifile: setup.cfg
collected 2 items

tests/unit/test_main.py ..                                                                                                             [100%]

============================================================== warnings summary ==============================================================
tests/unit/test_main.py::TestMain::test_get_controller_status
tests/unit/test_main.py::TestMain::test_get_napps_info
  /status/.tox/py36/src/kytos/kytos/core/config.py:167: UserWarning: Unknown arguments: ['tests/unit']
    warnings.warn(f"Unknown arguments: {unknown}")

-- Docs: https://docs.pytest.org/en/latest/warnings.html
======================================================= 2 passed, 2 warnings in 1.51s ========================================================
Name          Stmts   Miss  Cover
---------------------------------
__init__.py       0      0   100%
main.py          15      0   100%
settings.py       0      0   100%
---------------------------------
TOTAL            15      0   100%
lint installed: astroid==2.0.4,attrs==20.3.0,backcall==0.1.0,click==7.1.1,coverage==5.0.3,decorator==4.4.2,docopt==0.6.2,docutils==0.16,first==2.0.1,Flask==1.1.2,Flask-Cors==3.0.8,Flask-SocketIO==4.2.1,importlib-metadata==4.0.1,ipython==7.13.0,ipython-genutils==0.2.0,isort==4.3.4,itsdangerous==1.1.0,janus==0.4.0,jedi==0.16.0,Jinja2==2.11.1,-e git+https://github.com/kytos/kytos.git@4633321b3dcc4d1ee4c01cdaa19bbb1833a47fdf#egg=kytos,-e git+http://github.com/kytos/status@f78b16e75a6bc074091270e431fa49f6902af898#egg=kytos_status,lazy-object-proxy==1.3.1,lockfile==0.12.2,MarkupSafe==1.1.1,mccabe==0.6.1,more-itertools==8.7.0,packaging==20.9,parso==0.6.2,pathtools==0.1.2,pexpect==4.8.0,pickleshare==0.7.5,pip-tools==2.0.2,pluggy==0.13.1,prompt-toolkit==3.0.5,ptyprocess==0.6.0,py==1.6.0,pycodestyle==2.4.0,pydocstyle==2.1.1,Pygments==2.7.1,PyJWT==1.7.1,pylint==2.1.1,pyparsing==2.4.7,pytest==5.4.1,python-daemon==2.2.4,python-engineio==3.12.1,-e git+http://github.com/kytos/status@f78b16e75a6bc074091270e431fa49f6902af898#egg=python_openflow,python-socketio==4.5.1,six==1.15.0,snowballstemmer==1.2.1,tox==3.2.1,traitlets==4.3.3,typed-ast==1.1.0,typing-extensions==3.7.4.3,virtualenv==16.0.0,watchdog==0.10.2,wcwidth==0.1.9,Werkzeug==1.0.1,wrapt==1.10.11,yala==1.7.0,zipp==3.4.1
lint run-test-pre: PYTHONHASHSEED='3773981176'
lint run-test: commands[0] | python setup.py lint
running lint
Yala is running. It may take several seconds...
:) No issues found.
__________________________________________________________________ summary ___________________________________________________________________
  coverage: commands succeeded
  lint: commands succeeded
  congratulations :)
```

### :page_facing_up: Release Notes

- Update development dependencies to match Kytos 2020.2 release: six, click - pluggy
